### PR TITLE
pdksync - use Puppet 8 and Ruby 3.2 in CI pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        puppet_version: [7]
+        puppet_version: [8]
 
     name: Check / Puppet ${{ matrix.puppet_version }}
     runs-on: ubuntu-24.04
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['rocky8', 'ub2404', 'deb12']
-        puppet_version: [7]
+        puppet_version: [8]
 
     name: Acceptance / ${{ matrix.os }} / Puppet ${{ matrix.puppet_version }}
     runs-on: ubuntu-24.04
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Run Litmus


### PR DESCRIPTION
use Puppet 8 and Ruby 3.2 in CI pipelines
pdk version: `3.4.0` 
